### PR TITLE
ツイッター検索変更

### DIFF
--- a/app/src/main/java/com/example/a1521315/test02/Search.java
+++ b/app/src/main/java/com/example/a1521315/test02/Search.java
@@ -26,7 +26,7 @@ public class Search extends Activity {
 
             //Uri uri = Uri.parse("https://twitter.com/intent/tweet?hashtags=けんかつ！APP &text=ぼくはけんこうです！やったー！");
             //Uri uri = Uri.parse("http://hashtagsjp.appspot.com/tag/けんかつ！APP");
-            Uri uri = Uri.parse("https://twitter.com/search?q=＃けんかつ！APP");
+            Uri uri = Uri.parse("https://twitter.com/search?q=＃けんかつAPP");
             Intent i = new Intent(Intent.ACTION_VIEW,uri);
             startActivity(i);
 


### PR DESCRIPTION
「！」が入っているとハッシュタグが切れるのでそれを修正
